### PR TITLE
Add tests to the Windows CI

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -90,6 +90,19 @@ jobs:
           - PYTHON_VERSION: "3.11"
             PYARROW_VERSION: "14.0.1"
     steps:
+      - name: Create SQL Server
+        shell: pwsh
+        run: |
+          Write-Host "Downloading"
+          Import-Module BitsTransfer
+          Start-BitsTransfer -Source "https://download.microsoft.com/download/3/8/d/38de7036-2433-4207-8eae-06e247e17b25/SqlLocalDB.msi" -Destination SqlLocalDB.msi
+          Write-Host "Installing"
+          Start-Process -FilePath "SqlLocalDB.msi" -Wait -ArgumentList "/qn", "/norestart", "/l*v SqlLocalDBInstall.log", "IACCEPTSQLLOCALDBLICENSETERMS=YES"
+          sqlcmd -S '(localdb)\MSSQLLocalDB' -Q 'CREATE DATABASE test_db' -l 60
+      - name: Configure ODBC Data Source
+        run: |
+          odbcconf /a {CONFIGDSN "ODBC Driver 17 for SQL Server" "DSN=MSSQL|Server=(localdb)\MSSQLLocalDB|Database=test_db|Trusted_Connection=Yes"}
+          if %errorlevel% neq 0 exit /b %errorlevel%
       - name: Checkout branch
         uses: actions/checkout@v3
         with:
@@ -101,11 +114,13 @@ jobs:
         with:
           condarc-file: .github/workflows/.condarc
           cache-env: true
+          environment-file: environment.yml
           extra-specs: |
             python=${{ matrix.PYTHON_VERSION }}
             pyarrow=${{ matrix.PYARROW_VERSION }}
             pytest-md
             pytest-emoji
+            pytest-cov
       - name: Configure with CMake
         run: |
           @CALL micromamba activate turbodbc
@@ -142,4 +157,11 @@ jobs:
           python -c "import turbodbc"
           if %errorlevel% neq 0 exit /b %errorlevel%
           python -c "import turbodbc.arrow_support"
+          if %errorlevel% neq 0 exit /b %errorlevel%
+      - name: Run tests
+        run: |
+          @CALL micromamba activate turbodbc
+          @echo on
+          cd build
+          ctest --verbose
           if %errorlevel% neq 0 exit /b %errorlevel%

--- a/cpp/cpp_odbc/Test/CMakeLists.txt
+++ b/cpp/cpp_odbc/Test/CMakeLists.txt
@@ -21,18 +21,19 @@ target_link_libraries(cpp_odbc_test
 )
 
 IF(UNIX)
-target_link_libraries(cpp_odbc_test
-    pthread
-)
+    target_link_libraries(cpp_odbc_test
+        pthread
+    )
 ENDIF()
 
 add_test(NAME cpp_odbc_unit_test
          COMMAND cpp_odbc_test --gtest_output=xml:${CMAKE_BINARY_DIR}/cpp_odbc_test.xml)
 
 IF(WIN32)
-set_tests_properties(
-    cpp_odbc_unit_test
-    PROPERTIES
-    ENVIRONMENT "PATH=${CMAKE_BINARY_DIR};$ENV{PATH}"
-)
+    string(REPLACE ";" "\\;" MASKED_PATH "$ENV{PATH}")
+    set_tests_properties(
+        cpp_odbc_unit_test
+        PROPERTIES
+        ENVIRONMENT "PATH=${CMAKE_BINARY_DIR}\;${MASKED_PATH}"
+    )
 ENDIF()

--- a/cpp/turbodbc/Test/CMakeLists.txt
+++ b/cpp/turbodbc/Test/CMakeLists.txt
@@ -24,18 +24,19 @@ target_link_libraries(turbodbc_test
 )
 
 IF(UNIX)
-target_link_libraries(turbodbc_test
-    pthread
-)
+    target_link_libraries(turbodbc_test
+        pthread
+    )
 ENDIF()
 
 add_test(NAME turbodbc_unit_test
          COMMAND turbodbc_test --gtest_output=xml:${CMAKE_BINARY_DIR}/turbodbc_test.xml)
 
 IF(WIN32)
-set_tests_properties(
-    turbodbc_unit_test
-    PROPERTIES
-    ENVIRONMENT "PATH=${CMAKE_BINARY_DIR};$ENV{PATH}"
-)
+    string(REPLACE ";" "\\;" MASKED_PATH "$ENV{PATH}")
+    set_tests_properties(
+        turbodbc_unit_test
+        PROPERTIES
+        ENVIRONMENT "PATH=${CMAKE_BINARY_DIR}\;${MASKED_PATH}"
+    )
 ENDIF()

--- a/cpp/turbodbc_arrow/Test/CMakeLists.txt
+++ b/cpp/turbodbc_arrow/Test/CMakeLists.txt
@@ -51,6 +51,6 @@ if (WIN32)
     set_tests_properties(
         turbodbc_arrow_unit_test
         PROPERTIES
-        ENVIRONMENT "PATH=${CMAKE_BINARY_DIR}\;${ARROW_LIBS}\;${MASKED_PATH}"
+        ENVIRONMENT "PATH=${ARROW_SEARCH_LIB_PATH_EXT}\;${CMAKE_BINARY_DIR}\;${ARROW_LIBS}\;${MASKED_PATH}"
     )
 endif()

--- a/python/turbodbc_test/CMakeLists.txt
+++ b/python/turbodbc_test/CMakeLists.txt
@@ -3,10 +3,19 @@ find_package(PythonInterp REQUIRED)
 add_test(
     NAME turbodbc_integration_test
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-    COMMAND py.test --cov=turbodbc -rP --junitxml=${CMAKE_BINARY_DIR}/turbodbc_python_test.xml --cov-report=xml:${CMAKE_BINARY_DIR}/python_cov.xml --cov-report=term-missing
+    COMMAND python -m pytest --cov=turbodbc -rP --junitxml=${CMAKE_BINARY_DIR}/turbodbc_python_test.xml --cov-report=xml:${CMAKE_BINARY_DIR}/python_cov.xml --cov-report=term-missing
 )
 set_tests_properties(
     turbodbc_integration_test
     PROPERTIES
     ENVIRONMENT PYTHONPATH=${CMAKE_BINARY_DIR}
 )
+set_tests_properties(turbodbc_integration_test PROPERTIES TIMEOUT 6000) # In seconds
+
+if (WIN32)
+    set_tests_properties(
+        turbodbc_integration_test
+        PROPERTIES
+        ENVIRONMENT "TURBODBC_TEST_CONFIGURATION_FILES=query_fixtures_mssql_win.json"
+    )
+endif()

--- a/python/turbodbc_test/helpers.py
+++ b/python/turbodbc_test/helpers.py
@@ -115,7 +115,7 @@ for_one_database = pytest.mark.parametrize(
 
 def for_specific_databases(db_filter: Optional[str] = None):
     """
-    Use this decorator to execute a test function for a specific database configuration.
+    Use this decorator to execute a test function for a specific database configuration that contains the given filter.
 
     Please note the test function *must* take the parameters `dsn` and `configuration`,
     and in that order.

--- a/python/turbodbc_test/helpers.py
+++ b/python/turbodbc_test/helpers.py
@@ -1,6 +1,7 @@
 import json
 import os
 from contextlib import contextmanager
+from typing import Optional, List
 
 import pytest
 
@@ -110,6 +111,25 @@ def test_important_stuff(dsn, configuration):
 for_one_database = pytest.mark.parametrize(
     "dsn,configuration", [_get_configuration(_get_config_files()[0])]
 )
+
+
+def for_specific_databases(db_filter: Optional[str] = None):
+    """
+    Use this decorator to execute a test function for a specific database configuration.
+
+    Please note the test function *must* take the parameters `dsn` and `configuration`,
+    and in that order.
+
+    Example:
+
+    @for_specific_databases("mssql")
+    def test_important_stuff_only_for_mssql(dsn, configuration):
+        assert 1 == 2
+    """
+    filtered_config_files = [fn for fn in _get_config_files() if db_filter in fn]
+    return pytest.mark.parametrize(
+        "dsn,configuration", [_get_configuration(cf) for cf in filtered_config_files]
+    )
 
 
 @contextmanager

--- a/python/turbodbc_test/query_fixtures_mssql_win.json
+++ b/python/turbodbc_test/query_fixtures_mssql_win.json
@@ -1,0 +1,128 @@
+{
+	"data_source_name": "MSSQL",
+	"prefer_unicode": true,
+
+	"capabilities": {
+		"supports_row_count": false,
+		"indicates_null_columns": true,
+		"reports_column_names_as_upper_case": false,
+		"fractional_second_digits": 6,
+		"connection_user_option": "uid",
+		"connection_password_option": "pwd"
+	},
+
+	"setup": {
+		"view": {
+			"create": ["DROP VIEW IF EXISTS {table_name}",
+			           "CREATE VIEW {table_name} AS {content}"],
+			"drop": ["DROP VIEW {table_name}"]
+		},
+		"table": {
+			"create": ["DROP TABLE IF EXISTS {table_name}",
+			           "CREATE TABLE {table_name} ({content})"],
+			"drop": ["DROP TABLE {table_name}"]
+		}
+	},
+
+	"queries": {
+		"SELECT DOUBLE": {
+			"view": "SELECT CAST(3.14 AS DOUBLE PRECISION) AS a",
+			"payload": "SELECT a FROM {table_name}"
+		},
+
+		"SELECT TRUE": {
+			"payload": "SELECT CAST(1 AS BIT) AS a"
+		},
+
+		"SELECT FALSE": {
+			"payload": "SELECT CAST(0 AS BIT) AS a"
+		},
+
+		"SELECT UNICODE": {
+			"payload": "SELECT N'I \u2665 unicode' AS a"
+		},
+
+		"SELECT MULTIPLE INTEGERS": {
+			"table": "a INTEGER",
+			"setup": ["INSERT INTO {table_name} VALUES (42), (43), (44)"],
+			"payload": "SELECT a FROM {table_name} ORDER BY a ASC"
+		},
+		
+		"SELECT TIMESTAMP": {
+			"payload": "SELECT CAST('2015-12-31 01:02:03' AS DATETIME2(6)) AS a"
+		},
+
+		"SELECT LARGE INTEGER DECIMAL": {
+			"payload": "SELECT CAST(42 AS DECIMAL(24, 0)) AS a"
+		},
+
+		"SELECT LARGE FRACTIONAL DECIMAL": {
+			"payload": "SELECT CAST(3.14 AS DECIMAL(24, 8)) AS a"
+		},
+	
+		"INSERT STRING": {
+			"table": "a VARCHAR(20)"
+		},
+
+		"INSERT STRING MAX": {
+			"table": "a VARCHAR(max)"
+		},
+
+		"INSERT UNICODE": {
+			"table": "a NVARCHAR(20)"
+		},
+
+		"INSERT UNICODE MAX": {
+			"table": "a NVARCHAR(max)"
+		},
+
+		"INSERT LONG STRING": {
+			"table": "a VARCHAR(1000)"
+		},
+	
+		"INSERT INTEGER": {
+			"table": "a INTEGER"
+		},
+		
+		"INSERT TWO INTEGER COLUMNS": {
+			"table": "a INTEGER, b INTEGER"
+		},
+		
+		"INSERT MIXED": {
+			"table": "a INTEGER, b DOUBLE PRECISION"
+		},
+	
+		"INSERT DOUBLE": {
+			"table": "a DOUBLE PRECISION"
+		},
+	
+		"INSERT BOOL": {
+			"table": "a BIT"
+		},
+		
+		"INSERT INDEXED BOOL": {
+			"table": "a BIT, b INTEGER"
+		},
+	
+		"INSERT DATE": {
+			"table": "a DATE"
+		},
+	
+		"INSERT TIMESTAMP": {
+			"table": "a DATETIME2(6)"
+		},
+
+		"INSERT DUPLICATE UNIQUECOL": {
+			"table": "a int NOT NULL, CONSTRAINT AK_a UNIQUE(a)",
+			"setup": ["INSERT INTO {table_name} VALUES (1)"]
+		},
+	
+		"DESCRIPTION": {
+			"table": "as_int INTEGER, as_double DOUBLE PRECISION, as_varchar VARCHAR(100), as_date DATE, as_timestamp DATETIME2(6), as_int_not_null INTEGER NOT NULL"
+		},
+
+		"UNICODE COLUMN NAME": {
+			"table": "[I \u2665 Unicode] INTEGER"
+		}
+	}
+}

--- a/python/turbodbc_test/test_connect.py
+++ b/python/turbodbc_test/test_connect.py
@@ -1,5 +1,5 @@
 import pytest
-from helpers import for_one_database, get_credentials
+from helpers import for_one_database, get_credentials, for_specific_databases
 
 from turbodbc import DatabaseError, ParameterError, connect
 from turbodbc.connect import _make_connection_string
@@ -44,7 +44,7 @@ def test_connect_raises_on_invalid_dsn():
         connect(invalid_dsn)
 
 
-@for_one_database
+@for_specific_databases("postgres")
 def test_connect_raises_on_invalid_additional_option(dsn, configuration):
     additional_option = {
         configuration["capabilities"]["connection_user_option"]: "invalid user"

--- a/python/turbodbc_test/test_cursor_nextset.py
+++ b/python/turbodbc_test/test_cursor_nextset.py
@@ -1,4 +1,4 @@
-from helpers import for_each_database_except, for_one_database, get_credentials
+from helpers import for_each_database_except, for_one_database, get_credentials, for_specific_databases
 
 from turbodbc import connect
 
@@ -21,7 +21,7 @@ def test_nextset_with_one_result_set(dsn, configuration):
         assert True, "Found call for nextset"
 
 
-@for_one_database
+@for_specific_databases("postgres")
 def test_nextset_with_function(dsn, configuration):
     cursor = connect(dsn, **get_credentials(configuration)).cursor()
     multi_result_set_func = """CREATE FUNCTION TEST_FUNC ()
@@ -43,7 +43,7 @@ def test_nextset_with_function(dsn, configuration):
         assert True, "Found call for nextset"
 
 
-@for_one_database
+@for_specific_databases("postgres")
 def test_nextset_with_postgres_procedure(dsn, configuration):
     cursor = connect(dsn, **get_credentials(configuration)).cursor()
     multi_result_set_func = """CREATE PROCEDURE TEST_PROC(INOUT _result_one
@@ -72,7 +72,7 @@ def test_nextset_with_postgres_procedure(dsn, configuration):
         assert True, "Found call for nextset"
 
 
-@for_one_database
+@for_specific_databases("postgres")
 def test_nextset_with_postgres_function(dsn, configuration):
     cursor = connect(dsn, **get_credentials(configuration)).cursor()
     multi_result_set_func = """CREATE FUNCTION TEST_FUNC() RETURNS SETOF refcursor as $$


### PR DESCRIPTION
Adds Windows CI tests, so that Windows-specific changes like those in https://github.com/blue-yonder/turbodbc/pull/400 are also covered.

Sadly, we cannot use Earthly with containers on Windows, but I replicated it with relatively little effort.